### PR TITLE
Fix applyClassMixins overwritting name and constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Mixins
 
-[![version](https://img.shields.io/badge/release-0.7.4-success)](https://github.com/udibo/mixins/tree/0.7.4)
-[![deno doc](https://doc.deno.land/badge.svg)](https://doc.deno.land/https/deno.land/x/mixins@0.7.4/mod.ts)
+[![version](https://img.shields.io/badge/release-0.8.0-success)](https://github.com/udibo/mixins/tree/0.8.0)
+[![deno doc](https://doc.deno.land/badge.svg)](https://doc.deno.land/https/deno.land/x/mixins@0.8.0/mod.ts)
 [![CI](https://github.com/udibo/mixins/workflows/CI/badge.svg)](https://github.com/udibo/mixins/actions?query=workflow%3ACI)
 [![codecov](https://codecov.io/gh/udibo/mixins/branch/master/graph/badge.svg?token=LIK8G3SMOC)](https://codecov.io/gh/udibo/mixins)
 [![license](https://img.shields.io/github/license/udibo/mixins)](https://github.com/udibo/mixins/blob/master/LICENSE)
@@ -28,9 +28,9 @@ imported directly from GitHub using raw content URLs.
 
 ```ts
 // Import from Deno's third party module registry
-import { applyMixins } from "https://deno.land/x/mixins@0.7.4/mod.ts";
+import { applyMixins } from "https://deno.land/x/mixins@0.8.0/mod.ts";
 // Import from GitHub
-import { applyMixins } "https://raw.githubusercontent.com/udibo/mixins/0.7.4/mod.ts";
+import { applyMixins } "https://raw.githubusercontent.com/udibo/mixins/0.8.0/mod.ts";
 ```
 
 ### Node.js
@@ -41,7 +41,7 @@ If a Node.js package has the type "module" specified in its package.json file,
 the JavaScript bundle can be imported as a `.js` file.
 
 ```js
-import { applyMixins } from "./mixins_0.7.4.js";
+import { applyMixins } from "./mixins_0.8.0.js";
 ```
 
 The default type for Node.js packages is "commonjs". To import the bundle into a
@@ -49,7 +49,7 @@ commonjs package, the file extension of the JavaScript bundle must be changed
 from `.js` to `.mjs`.
 
 ```js
-import { applyMixins } from "./mixins_0.7.4.mjs";
+import { applyMixins } from "./mixins_0.8.0.mjs";
 ```
 
 See [Node.js Documentation](https://nodejs.org/api/esm.html) for more
@@ -68,7 +68,7 @@ modules must have the type attribute set to "module".
 
 ```js
 // main.js
-import { applyMixins } from "./mixins_0.7.4.js";
+import { applyMixins } from "./mixins_0.8.0.js";
 ```
 
 You can also embed a module script directly into an HTML file by placing the
@@ -76,7 +76,7 @@ JavaScript code within the body of the script tag.
 
 ```html
 <script type="module">
-  import { applyMixins } from "./mixins_0.7.4.js";
+  import { applyMixins } from "./mixins_0.8.0.js";
 </script>
 ```
 
@@ -96,7 +96,7 @@ Applies properties of mixins to instance.
 Using `applyMixins` to add properties to an object:
 
 ```ts
-import { applyMixins } from "https://deno.land/x/mixins@0.7.4/mod.ts";
+import { applyMixins } from "https://deno.land/x/mixins@0.8.0/mod.ts";
 interface Point {
   x: number;
   y: number;
@@ -118,7 +118,7 @@ point3; // { time: 5, x: 2, y: 3, z: 7 }
 Using `applyMixins` to add properties to a function:
 
 ```ts
-import { applyMixins } from "https://deno.land/x/mixins@0.7.4/mod.ts";
+import { applyMixins } from "https://deno.land/x/mixins@0.8.0/mod.ts";
 interface Point {
   x: number;
   y: number;
@@ -158,7 +158,7 @@ point3.toString(); // "2, 3, 7, 5"
 Using `applyMixins` to add properties to a class:
 
 ```ts
-import { applyMixins } from "https://deno.land/x/mixins@0.7.4/mod.ts";
+import { applyMixins } from "https://deno.land/x/mixins@0.8.0/mod.ts";
 interface Point {
   x: number;
   y: number;
@@ -215,7 +215,7 @@ Applies properties of base class prototypes to instance.
 import {
   applyInstanceMixins,
   applyMixins,
-} from "https://deno.land/x/mixins@0.7.4/mod.ts";
+} from "https://deno.land/x/mixins@0.8.0/mod.ts";
 class Point {
   constructor(public x: number, public y: number) {}
 
@@ -265,7 +265,7 @@ Applies properties of base class prototypes to class prototype.
 import {
   applyClassMixins,
   applyMixins,
-} from "https://deno.land/x/mixins@0.7.4/mod.ts";
+} from "https://deno.land/x/mixins@0.8.0/mod.ts";
 class Point {
   constructor(public x: number, public y: number) {}
 

--- a/apply.ts
+++ b/apply.ts
@@ -5,7 +5,11 @@
 export function applyMixins<T>(instance: T, mixins: any[]) {
   mixins.forEach((mixin) => {
     Object.getOwnPropertyNames(mixin).forEach((name) => {
-      if (name === "prototype") return;
+      // if (name === "prototype") return;
+      if (
+        name === "prototype" || name === "name" || name === "constructor" ||
+        name === "length"
+      ) return;
       Object.defineProperty(
         instance,
         name,

--- a/apply_test.ts
+++ b/apply_test.ts
@@ -1,4 +1,8 @@
-import { assertEquals } from "./test_deps.ts";
+import {
+  assertEquals,
+  assertObjectMatch,
+  assertStrictEquals,
+} from "https://deno.land/std@0.201.0/assert/mod.ts";
 import { applyClassMixins, applyInstanceMixins, applyMixins } from "./mod.ts";
 
 Deno.test("applyMixins to object", () => {
@@ -181,7 +185,6 @@ Deno.test("applyInstanceMixins", () => {
   assertEquals(
     Object.getOwnPropertyNames(point).sort(),
     [
-      "constructor",
       "getPosition",
       "getTime",
       "length",
@@ -198,6 +201,8 @@ Deno.test("applyInstanceMixins", () => {
 
 Deno.test("applyClassMixins", () => {
   class Point {
+    static x = 2;
+
     constructor(public x: number, public y: number) {}
 
     static defaultPosition(): [number, number] {
@@ -209,6 +214,7 @@ Deno.test("applyClassMixins", () => {
     }
   }
   class TimePoint {
+    static time = 5;
     constructor(public time: number) {}
 
     getTime(): number {
@@ -222,10 +228,10 @@ Deno.test("applyClassMixins", () => {
     toString(): string;
   }
   class Point4D {
-    static x: number;
-    static y: number;
-    static z: number;
-    static time: number;
+    declare static x: number;
+    declare static y: number;
+    declare static z: number;
+    declare static time: number;
 
     constructor(
       public x: number,
@@ -248,7 +254,7 @@ Deno.test("applyClassMixins", () => {
     }
   }
   applyClassMixins(Point4D, [Point, TimePoint, Point4DPartial]);
-  applyMixins(Point4D, [{ time: 5, x: 2, y: 3, z: 7 }]);
+  applyMixins(Point4D, [{ y: 3, z: 7 }]);
 
   assertEquals(Point4D.example(), "2, 3, 7, 5");
   assertEquals(
@@ -269,12 +275,21 @@ Deno.test("applyClassMixins", () => {
     Object.getOwnPropertyNames(Point4D.prototype).sort(),
     ["constructor", "getPosition", "getTime", "toArray", "toString"],
   );
+  assertEquals(Point4D.name, "Point4D");
+  assertStrictEquals(Point4D.prototype.constructor, Point4D);
+  assertObjectMatch(Point4D, {
+    x: 2,
+    y: 3,
+    z: 7,
+    time: 5,
+  });
 
   applyMixins(Point4D, [{ x: 10, y: 16 }, { y: 18, z: 22 }]);
   assertEquals(Point4D.example(), "10, 18, 22, 5");
 
   const point: Point4D = new Point4D(1, 2, 3, 4);
 
+  assertStrictEquals(point.constructor, Point4D);
   assertEquals(point.toArray(), [1, 2, 3, 4]);
   assertEquals(point.toString(), "1, 2, 3, 4");
   assertEquals(point.getPosition(), "1, 2");

--- a/test_deps.ts
+++ b/test_deps.ts
@@ -1,1 +1,0 @@
-export { assertEquals } from "https://deno.land/std@0.107.0/testing/asserts.ts";


### PR DESCRIPTION
Point4D's name and constructor keys were getting overwritten, which ended up causing issues for me when I started using the function in one of my other projects. This fixes that issue so that applyClassMixins would work the way you would expect it to.